### PR TITLE
Fix install script to allow other clone locations

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 repo=motors-sync
-repo_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+repo_path="$(cd "$(dirname "$0")" && pwd)"
 
 # Сворачивание от root
 if [ "$(id -u)" = "0" ]; then

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 repo=motors-sync
-repo_path=~/motors-sync/
+repo_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Сворачивание от root
 if [ "$(id -u)" = "0" ]; then


### PR DESCRIPTION
Fix for people who do not clone the repo into their root dir

https://saturncloud.io/blog/how-to-get-the-directory-where-a-bash-script-is-located/