### PR TITLE
Fix reference from self.axes to new self.conf_axes

### DIFF
--- a/motors_sync.py
+++ b/motors_sync.py
@@ -462,7 +462,7 @@ class MotorsSync:
             return f'Access to interactive plot at: {png_path}'
 
         repeats = gcmd.get_int('REPEATS', 10, minval=1, maxval=100)
-        axis = gcmd.get_int('AXIS', self.axes[0])
+        axis = gcmd.get_int('AXIS', self.conf_axes[0])
         self.gcode.respond_info('Synchronizing before calibration')
         self.cmd_RUN_SYNC(gcmd)
         m = self.motion[axis]


### PR DESCRIPTION
Looks like current head crashes on `SYNC_MOTORS_CALIBRATE` with this error:

```
Traceback (most recent call last):
  File "/home/tim/klipper/klippy/webhooks.py", line 282, in _process_request
    func(web_request)
  File "/home/tim/klipper/klippy/webhooks.py", line 481, in _handle_script
    self.gcode.run_script(web_request.get_str("script"))
  File "/home/tim/klipper/klippy/gcode.py", line 321, in run_script
    self._process_commands(script.split("\n"), need_ack=False)
  File "/home/tim/klipper/klippy/gcode.py", line 298, in _process_commands
    handler(gcmd)
  File "/home/tim/klipper/klippy/gcode.py", line 207, in func
    return origfunc(self._get_extended_params(params))
  File "/home/tim/klipper/klippy/extras/motors_sync.py", line 465, in cmd_CALIBRATE_SYNC
    axis = gcmd.get_int('AXIS', self.axes[0])
AttributeError: 'MotorsSync' object has no attribute 'axes'
```

The breakage seems to have been caused by 456b54efbd9baecf9a082a694c87ead79133ca5e which changed the `self.axes` member to `self.conf_axes`.