### PR TITLE
adding colored icons for X and Y specific messages

### DIFF
--- a/motors_sync.py
+++ b/motors_sync.py
@@ -859,6 +859,11 @@ class MotorsSync:
                 axis.fan_switch(True)
                 axis.chip_helper.finish_measurements()
             raise self.gcode.error(state)
+        # 🔵🟡 Add icons before sending
+        if name.startswith("Y"):
+            msg = f"🟡 {msg}"
+        elif name.startswith("X"):
+            msg = f"🔵 {msg}"
         self.gcode.respond_info(msg, True)
 
     def _single_sync(self, m):
@@ -1369,3 +1374,4 @@ class StatisticsManager:
 
 def load_config(config):
     return MotorsSync(config)
+


### PR DESCRIPTION
Love this plugin but I always was bothered by the fact that it was hard to differentiate X and Y messages easily in the console. I added a couple of lines to add a colored icon before messages starting with X and Y.

Adding colored dot icons to easily differentiate X and Y mesages.